### PR TITLE
shared string fix

### DIFF
--- a/addons/excel_reader/src/workbook.gd
+++ b/addons/excel_reader/src/workbook.gd
@@ -80,9 +80,7 @@ func _init(zip_reader: ZIPReader):
 	# 获取值列表，string 类型单元格数据的缓存（共享的字符串）
 	var sharedStrings = ExcelXMLData.new(_zip_reader, "xl/sharedStrings.xml")
 	for si_node in sharedStrings.get_root().get_children():
-		if si_node.get_child_count() > 0:
-			var t_node = si_node.get_child(0)
-			shared_strings.append(t_node.get_value())
+		shared_strings.append(si_node.get_full_value())
 
 
 func _to_string():

--- a/addons/excel_reader/src/xml_node.gd
+++ b/addons/excel_reader/src/xml_node.gd
@@ -132,4 +132,10 @@ func find_nodes(_type: String) -> Array[ExcelXMLNode]:
 func get_value():
 	return value
 
-
+func get_full_value():
+	if value != "":
+		return value
+	var ret: String = ""
+	for child in get_children():
+		ret += child.get_full_value()
+	return ret


### PR DESCRIPTION
Sometimes the shared string in excel file is styled text (i.e. has bold, italic, etc.). The old code cannot read it correctly (since it does not have a single text field). The new code combines all text field of its children nodes, which should work correctly for more excel files.